### PR TITLE
Switch to using the NPPM_GETOPENFILENAMES_DEPRECATED for now

### DIFF
--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -385,7 +385,7 @@ void getFileNamesDemo()
 		fileNames[i] = new TCHAR[MAX_PATH];
 	}
 
-	if (::SendMessage(nppData._nppHandle, NPPM_GETOPENFILENAMES, (WPARAM)fileNames, (LPARAM)nbFile))
+	if (::SendMessage(nppData._nppHandle, NPPM_GETOPENFILENAMES_DEPRECATED, (WPARAM)fileNames, (LPARAM)nbFile))
 	{
 		for (int i = 0 ; i < nbFile ; i++)
 		::MessageBox(nppData._nppHandle, fileNames[i], TEXT(""), MB_OK);


### PR DESCRIPTION
per #10, use the `NPPM_GETOPENFILENAMES_DEPRECATED` name for the message for now.  (should tide us over until the new interface is defined)

does _not_ close the issue yet.  just a temporary fix to tide us over.